### PR TITLE
unify the design of login page

### DIFF
--- a/frontend/src/pages/settings/history-section.ts
+++ b/frontend/src/pages/settings/history-section.ts
@@ -101,18 +101,18 @@ export class HistorySection {
 
     return `
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-gray-900/40 rounded border border-cyan-500/20">
-        <div class="text-center">
-          <p class="text-2xl font-bold text-cyan-400">${this.stats.totalGames}</p>
-          <p class="text-xs text-gray-400">Total Games</p>
-        </div>
-        <div class="text-center">
-          <p class="text-2xl font-bold text-green-400">${this.stats.wins}</p>
-          <p class="text-xs text-gray-400">Wins</p>
-        </div>
-        <div class="text-center">
-          <p class="text-2xl font-bold text-red-400">${this.stats.losses}</p>
-          <p class="text-xs text-gray-400">Losses</p>
-        </div>
+      <div class="text-center">
+      <p class="text-2xl font-bold text-green-400">${this.stats.wins}</p>
+      <p class="text-xs text-gray-400">Wins</p>
+      </div>
+      <div class="text-center">
+      <p class="text-2xl font-bold text-red-400">${this.stats.losses}</p>
+      <p class="text-xs text-gray-400">Losses</p>
+      </div>
+      <div class="text-center">
+        <p class="text-2xl font-bold text-cyan-400">${this.stats.totalGames}</p>
+        <p class="text-xs text-gray-400">Total Games</p>
+      </div>
         <div class="text-center">
           <p class="text-2xl font-bold text-purple-400">${this.stats.winRate.toFixed(1)}%</p>
           <p class="text-xs text-gray-400">Win Rate</p>

--- a/frontend/src/pages/settings/security-section.ts
+++ b/frontend/src/pages/settings/security-section.ts
@@ -247,7 +247,6 @@ export class SecuritySection {
 
     dialogContent.innerHTML = "";
     this.twoFactorComponent = new TwoFactorVerification(dialogContent, {
-      mode: "modal",
       message: this.buildTwoFactorMessage(challenge),
       resendLabel: "Resend Code",
       cancelLabel: "Cancel",

--- a/frontend/src/shared/components/login-form.ts
+++ b/frontend/src/shared/components/login-form.ts
@@ -10,9 +10,6 @@ import type {
 } from "../types/user";
 import { setupPasswordToggles } from "../utils/password-toggle-utils";
 
-const eyeIconUrl = new URL("../../../images/icon/eye_icon.png", import.meta.url)
-  .href;
-
 interface LoginErrorTranslations {
   required?: string;
   generic?: string;
@@ -73,60 +70,60 @@ export class LoginForm {
     this.twoFactorComponent = null;
 
     this.container.innerHTML = `
-      <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-bold mb-4 text-center">${this.t.title || "Login"}</h2>
+      <div class="border border-cyan-500/30 rounded-lg p-6 bg-gray-900/95 shadow-xl backdrop-blur-sm">
+        <h2 class="text-2xl font-bold mb-4 text-center text-cyan-200">${this.t.title || "Login"}</h2>
         <form id="login-form" class="space-y-4">
           <div>
-            <label for="email" class="block text-sm font-medium text-gray-700">${this.t.emailLabel || "Email"}</label>
+            <label for="email" class="block text-sm font-medium text-gray-200">${this.t.emailLabel || "Email"}</label>
             <input
               type="email"
               id="email"
               name="email"
               required
-              class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              class="mt-1 block w-full px-3 py-2 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400"
               placeholder="${this.t.emailPlaceholder || "Enter your email"}"
             >
           </div>
           <div>
-            <label for="password" class="block text-sm font-medium text-gray-700">${this.t.passwordLabel || "Password"}</label>
+            <label for="password" class="block text-sm font-medium text-gray-200">${this.t.passwordLabel || "Password"}</label>
             <div class="mt-1 relative">
               <input
                 type="password"
                 id="password"
                 name="password"
                 required
-                class="block w-full px-3 py-2 pr-10 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                class="block w-full px-3 py-2 pr-10 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400"
                 placeholder="${this.t.passwordPlaceholder || "Enter your password"}"
               >
               <button
                 type="button"
-                class="password-toggle absolute inset-y-0 right-3 flex items-center text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="password-toggle absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-500"
                 aria-label="Show password"
                 data-target="password"
                 data-visible="false"
               ></button>
             </div>
           </div>
-          <div id="error-message" class="hidden text-red-600 text-sm"></div>
+          <div id="error-message" class="hidden text-red-300 text-sm"></div>
           <div class="space-y-2">
-            <button 
-              type="submit" 
+            <button
+              type="submit"
               id="login-submit"
-              class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full bg-cyan-600 hover:bg-cyan-500 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-cyan-500"
             >
               ${this.t.submit || "Login"}
             </button>
-            <button 
-              type="button" 
+            <button
+              type="button"
               id="show-register"
-              class="w-full bg-gray-700 hover:bg-gray-800 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-700"
+              class="w-full bg-gray-700 hover:bg-gray-600 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-700"
             >
               ${this.t.register || "Don't have an account? Register"}
             </button>
-            <button 
-              type="button" 
+            <button
+              type="button"
               id="show-home"
-              class="w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+              class="w-full bg-gray-800 hover:bg-gray-700 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
             >
               ${this.t.home || "Back to Home"}
             </button>
@@ -136,7 +133,7 @@ export class LoginForm {
     `;
 
     this.attachLoginListeners();
-    setupPasswordToggles(this.container, eyeIconUrl);
+    setupPasswordToggles(this.container);
   }
 
   private renderTwoFactorView(): void {
@@ -162,7 +159,6 @@ export class LoginForm {
     }
 
     this.twoFactorComponent = new TwoFactorVerification(dialogContainer, {
-      mode: "modal",
       message: this.buildTwoFactorMessage(this.twoFactorChallenge),
       resendLabel: "Resend email code",
       cancelLabel: "Back to Login",

--- a/frontend/src/shared/components/register-form.ts
+++ b/frontend/src/shared/components/register-form.ts
@@ -2,9 +2,6 @@ import { AuthService } from "../services/auth-service";
 import type { CreateUserRequest, PublicUser } from "../types/user";
 import { setupPasswordToggles } from "../utils/password-toggle-utils";
 
-const eyeIconUrl = new URL("../../../images/icon/eye_icon.png", import.meta.url)
-  .href;
-
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export class RegisterForm {
@@ -20,11 +17,11 @@ export class RegisterForm {
 
   private render(): void {
     this.container.innerHTML = `
-      <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-2xl font-bold mb-4 text-center">Create an Account</h2>
+      <div class="border border-cyan-500/30 rounded-lg p-6 bg-gray-900/95 shadow-xl backdrop-blur-sm">
+        <h2 class="text-2xl font-bold mb-4 text-center text-cyan-200">Create an Account</h2>
         <form id="register-form" class="space-y-4">
           <div>
-            <label for="username" class="block text-sm font-medium text-gray-700">Username</label>
+            <label for="username" class="block text-sm font-medium text-gray-200">Username</label>
             <input
               type="text"
               id="username"
@@ -32,23 +29,23 @@ export class RegisterForm {
               required
               minlength="3"
               maxlength="20"
-              class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              class="mt-1 block w-full px-3 py-2 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400"
               placeholder="Choose a username"
             >
           </div>
           <div>
-            <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+            <label for="email" class="block text-sm font-medium text-gray-200">Email</label>
             <input
               type="email"
               id="email"
               name="email"
               required
-              class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              class="mt-1 block w-full px-3 py-2 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400"
               placeholder="you@example.com"
             >
           </div>
           <div>
-            <label for="password" class="block text-sm font-medium text-gray-700">Password</label>
+            <label for="password" class="block text-sm font-medium text-gray-200">Password</label>
             <div class="mt-1 relative">
               <input
                 type="password"
@@ -56,59 +53,59 @@ export class RegisterForm {
                 name="password"
                 required
                 minlength="6"
-                class="block w-full px-3 py-2 pr-10 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                class="block w-full px-3 py-2 pr-10 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400"
                 placeholder="Enter a secure password"
               >
               <button
                 type="button"
-                class="password-toggle absolute inset-y-0 right-3 flex items-center text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="password-toggle absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-500"
                 aria-label="Show password"
                 data-target="password"
                 data-visible="false"
               ></button>
             </div>
-            <p class="text-xs text-gray-500 mt-1">At least 6 characters.</p>
+            <p class="text-xs text-gray-400 mt-1">At least 6 characters.</p>
           </div>
           <div>
-            <label for="confirm-password" class="block text-sm font-medium text-gray-700">Confirm Password</label>
+            <label for="confirm-password" class="block text-sm font-medium text-gray-200">Confirm Password</label>
             <div class="mt-1 relative">
               <input
                 type="password"
                 id="confirm-password"
                 name="confirm-password"
                 required
-                class="block w-full px-3 py-2 pr-10 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                class="block w-full px-3 py-2 pr-10 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400"
                 placeholder="Re-enter your password"
               >
               <button
                 type="button"
-                class="password-toggle absolute inset-y-0 right-3 flex items-center text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                class="password-toggle absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-500"
                 aria-label="Show password"
                 data-target="confirm-password"
                 data-visible="false"
               ></button>
             </div>
           </div>
-          <div id="register-error-message" class="hidden text-red-600 text-sm"></div>
+          <div id="register-error-message" class="hidden text-red-300 text-sm"></div>
           <div class="space-y-2">
             <button
               type="submit"
               id="register-submit"
-              class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full bg-cyan-600 hover:bg-cyan-500 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-cyan-500"
             >
               Create account
             </button>
             <button
               type="button"
               id="show-login"
-              class="w-full bg-gray-700 hover:bg-gray-800 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-700"
+              class="w-full bg-gray-700 hover:bg-gray-600 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-700"
             >
               Already have an account? Sign in
             </button>
             <button
               type="button"
               id="register-show-home"
-              class="w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+              class="w-full bg-gray-800 hover:bg-gray-700 text-white py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
             >
               Back to Home
             </button>
@@ -118,7 +115,7 @@ export class RegisterForm {
     `;
 
     this.attachEventListeners();
-    setupPasswordToggles(this.container, eyeIconUrl);
+    setupPasswordToggles(this.container);
   }
 
   private attachEventListeners(): void {

--- a/frontend/src/shared/components/two-factor-verification.ts
+++ b/frontend/src/shared/components/two-factor-verification.ts
@@ -1,5 +1,4 @@
 export interface TwoFactorVerificationOptions {
-  mode?: "inline" | "modal";
   message: string;
   verifyLabel?: string;
   resendLabel?: string;
@@ -18,7 +17,6 @@ export class TwoFactorVerification {
     onResend?: () => Promise<void>;
     onCancel?: () => void;
   };
-  private readonly isModal: boolean;
   private elements!: {
     message: HTMLElement;
     form: HTMLFormElement;
@@ -33,7 +31,6 @@ export class TwoFactorVerification {
   constructor(container: HTMLElement, options: TwoFactorVerificationOptions) {
     this.container = container;
     this.options = {
-      mode: options.mode ?? "inline",
       message: options.message,
       verifyLabel: options.verifyLabel ?? "Verify Code",
       resendLabel: options.resendLabel ?? "Resend email code",
@@ -44,8 +41,6 @@ export class TwoFactorVerification {
       onCancel: options.onCancel,
     };
 
-    this.isModal = this.options.mode === "modal";
-
     this.render();
     this.attachListeners();
   }
@@ -54,28 +49,21 @@ export class TwoFactorVerification {
     this.container.innerHTML = "";
 
     const wrapper = document.createElement("div");
-    wrapper.className = this.isModal
-      ? "border border-cyan-500/30 rounded-lg p-6 bg-gray-900/95 shadow-xl backdrop-blur-sm"
-      : "border border-gray-200 rounded-lg p-6 bg-white shadow-sm";
+    wrapper.className =
+      "border border-cyan-500/30 rounded-lg p-6 bg-gray-900/95 shadow-xl backdrop-blur-sm";
 
     const title = document.createElement("h2");
-    title.className = this.isModal
-      ? "text-2xl font-bold mb-4 text-center text-cyan-200"
-      : "text-2xl font-bold mb-4 text-center text-gray-900";
+    title.className = "text-2xl font-bold mb-4 text-center text-cyan-200";
     title.textContent = "Two-Factor Verification";
 
     const message = document.createElement("p");
     message.dataset.message = "";
-    message.className = this.isModal
-      ? "text-sm text-gray-300 mb-2"
-      : "text-sm text-gray-500 mb-2";
+    message.className = "text-sm text-gray-300 mb-2";
     message.textContent = this.options.message;
 
     const feedback = document.createElement("p");
     feedback.dataset.feedback = "";
-    feedback.className = this.isModal
-      ? "hidden text-sm mb-4 text-gray-300"
-      : "hidden text-sm mb-4 text-gray-500";
+    feedback.className = "hidden text-sm mb-4 text-gray-300";
     feedback.setAttribute("role", "status");
 
     const form = document.createElement("form");
@@ -89,9 +77,7 @@ export class TwoFactorVerification {
 
     const label = document.createElement("label");
     label.htmlFor = "code";
-    label.className = this.isModal
-      ? "text-sm font-medium text-gray-200"
-      : "text-sm font-medium text-gray-700";
+    label.className = "text-sm font-medium text-gray-200";
     label.textContent = "Verification Code";
 
     let resendButton: HTMLButtonElement | null = null;
@@ -99,9 +85,7 @@ export class TwoFactorVerification {
       resendButton = document.createElement("button");
       resendButton.type = "button";
       resendButton.dataset.resend = "";
-      resendButton.className = this.isModal
-        ? "text-cyan-300 hover:text-cyan-200 text-sm"
-        : "text-blue-600 hover:underline text-sm";
+      resendButton.className = "text-cyan-300 hover:text-cyan-200 text-sm";
       resendButton.textContent = this.options.resendLabel;
     }
 
@@ -113,9 +97,8 @@ export class TwoFactorVerification {
     input.maxLength = 6;
     input.required = true;
     input.inputMode = "numeric";
-    input.className = this.isModal
-      ? "block w-full px-3 py-2 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400 tracking-widest text-center"
-      : "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 tracking-widest text-center";
+    input.className =
+      "block w-full px-3 py-2 bg-gray-950 border border-cyan-500/40 rounded-md shadow-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-cyan-400 tracking-widest text-center";
     input.placeholder = "123456";
 
     labelRow.appendChild(label);
@@ -128,9 +111,7 @@ export class TwoFactorVerification {
 
     const error = document.createElement("div");
     error.dataset.error = "";
-    error.className = this.isModal
-      ? "hidden text-sm text-red-300"
-      : "hidden text-sm text-red-600";
+    error.className = "hidden text-sm text-red-300";
 
     const actions = document.createElement("div");
     actions.className = "space-y-2";
@@ -138,9 +119,8 @@ export class TwoFactorVerification {
     const submit = document.createElement("button");
     submit.type = "submit";
     submit.dataset.submit = "";
-    submit.className = this.isModal
-      ? "w-full bg-cyan-600 hover:bg-cyan-500 text-white py-2 px-4 rounded disabled:opacity-60"
-      : "w-full bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded disabled:opacity-60";
+    submit.className =
+      "w-full bg-cyan-600 hover:bg-cyan-500 text-white py-2 px-4 rounded disabled:opacity-60";
     submit.textContent = this.options.verifyLabel;
 
     let cancelButton: HTMLButtonElement | null = null;
@@ -148,9 +128,8 @@ export class TwoFactorVerification {
       cancelButton = document.createElement("button");
       cancelButton.type = "button";
       cancelButton.dataset.cancel = "";
-      cancelButton.className = this.isModal
-        ? "w-full bg-gray-700 hover:bg-gray-600 text-white py-2 px-4 rounded"
-        : "w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded";
+      cancelButton.className =
+        "w-full bg-gray-700 hover:bg-gray-600 text-white py-2 px-4 rounded";
       cancelButton.textContent = this.options.cancelLabel;
     }
 
@@ -273,9 +252,9 @@ export class TwoFactorVerification {
     variant: "success" | "info" | "error" = "success",
   ): void {
     const colors = {
-      success: this.isModal ? "text-green-300" : "text-green-600",
-      info: this.isModal ? "text-cyan-300" : "text-blue-600",
-      error: this.isModal ? "text-red-300" : "text-red-600",
+      success: "text-green-300",
+      info: "text-cyan-300",
+      error: "text-red-300",
     };
     this.elements.feedback.textContent = message;
     this.elements.feedback.className = `text-sm mb-4 ${colors[variant]}`;
@@ -283,8 +262,7 @@ export class TwoFactorVerification {
   }
 
   public clearFeedback(): void {
-    const baseColor = this.isModal ? "text-gray-300" : "text-gray-500";
-    this.elements.feedback.className = `hidden text-sm mb-4 ${baseColor}`;
+    this.elements.feedback.className = "hidden text-sm mb-4 text-gray-300";
     this.elements.feedback.textContent = "";
   }
 

--- a/frontend/src/shared/utils/password-toggle-utils.ts
+++ b/frontend/src/shared/utils/password-toggle-utils.ts
@@ -1,20 +1,23 @@
-const createToggleIcon = (isVisible: boolean, eyeIconUrl: string): string => {
-  const slashMarkup = isVisible
-    ? ""
-    : `<span class="absolute block" style="width: 1.35rem; height: 2px; background-color: currentColor; transform: rotate(45deg); border-radius: 9999px;"></span>`;
-
-  return `
-    <span class="relative inline-flex h-5 w-5 items-center justify-center">
-      <img src="${eyeIconUrl}" alt="" class="pointer-events-none h-5 w-5 object-contain" />
-      ${slashMarkup}
-    </span>
-  `;
+const createToggleIcon = (isVisible: boolean): string => {
+  if (isVisible) {
+    // Eye icon (visible state)
+    return `
+      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+      </svg>
+    `;
+  } else {
+    // Eye-slash icon (hidden state)
+    return `
+      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+      </svg>
+    `;
+  }
 };
 
-export const setupPasswordToggles = (
-  container: HTMLElement,
-  eyeIconUrl: string,
-): void => {
+export const setupPasswordToggles = (container: HTMLElement): void => {
   const toggles =
     container.querySelectorAll<HTMLButtonElement>(".password-toggle");
 
@@ -36,7 +39,7 @@ export const setupPasswordToggles = (
         "aria-label",
         visible ? "Hide password" : "Show password",
       );
-      toggle.innerHTML = createToggleIcon(visible, eyeIconUrl);
+      toggle.innerHTML = createToggleIcon(visible);
     };
 
     const initialVisible = toggle.dataset.visible === "true";


### PR DESCRIPTION
close #95 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ログインと登録フォームにダークテーマとシアンアクセントを適用
  * パスワードトグルアイコンをインラインSVGで改善

* **リファクター**
  * 統計カードの表示順序を再構成（勝利数、敗北数、総ゲーム数、勝率）
  * 二要素認証フローを簡素化し、条件付きスタイル設定を統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->