### PR TITLE
fix: トーナメントの参加人数を4人と8人にしてデフォルトを4人にした

### DIFF
--- a/frontend/src/pages/quick-play/index.ts
+++ b/frontend/src/pages/quick-play/index.ts
@@ -195,6 +195,8 @@ export class QuickPlayPage extends SpacePageBase {
         startButtonText,
         backButtonText,
         requireHumanPlayer: false,
+        playerCountOptions: [2, 4], // クイックプレイは2人と4人
+        defaultPlayerCount: 2, // デフォルトは2人
         translations: {
           setup: setupTranslations,
           playerSelector: this.playerSelectorCopy,

--- a/frontend/src/pages/tournament/tournament.service.ts
+++ b/frontend/src/pages/tournament/tournament.service.ts
@@ -353,6 +353,8 @@ export class TournamentService {
         startButtonText: buttons.startTournament || "Start Tournament",
         backButtonText: buttons.home || "Back to Home",
         requireHumanPlayer: true,
+        playerCountOptions: [4, 8], // トーナメントは4人と8人
+        defaultPlayerCount: 4, // デフォルトは4人
         translations: {
           setup: setup,
           playerSelector: playerSelector,

--- a/frontend/src/shared/components/player-registration-with-count-selector.ts
+++ b/frontend/src/shared/components/player-registration-with-count-selector.ts
@@ -18,6 +18,8 @@ export interface PlayerRegistrationWithCountConfig {
   startButtonText?: string;
   backButtonText?: string;
   requireHumanPlayer?: boolean;
+  playerCountOptions?: number[]; // 利用可能なプレイヤー数のオプション（例: [2, 4] または [4, 8]）
+  defaultPlayerCount?: number; // デフォルトのプレイヤー数
 
   translations?: RegistrationTranslations;
 
@@ -48,7 +50,8 @@ export class PlayerRegistrationWithCountSelector {
     this.destroy();
     this.playerRegistrationManager = new PlayerRegistrationManager();
     this.config = config;
-    this.currentPlayerCount = 2;
+    // 設定から取得、なければデフォルト値を使用
+    this.currentPlayerCount = config.defaultPlayerCount ?? 2;
 
     if (!config.container) {
       throw new Error("Container element is required");
@@ -136,7 +139,9 @@ export class PlayerRegistrationWithCountSelector {
   }
 
   private getPlayerCountOptionsHtml(setup: TranslationSection): string {
-    return [2, 4]
+    // 設定から取得、なければデフォルト値[2, 4]を使用
+    const options = this.config?.playerCountOptions ?? [2, 4];
+    return options
       .map((count) => {
         const labelTemplate = setup.playerOption || "{{count}} Players";
         const label = this.formatText(labelTemplate, {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クイックプレイでプレイヤー数の選択オプションを実装（2人/4人、初期値：2人）
  * トーナメント登録フローにプレイヤー数選択機能を追加（4人/8人、初期値：4人）
  * プレイヤー登録時のカウント設定をカスタマイズ可能に改良

<!-- end of auto-generated comment: release notes by coderabbit.ai -->